### PR TITLE
Remove factory pattern from HttpClient

### DIFF
--- a/src/FplClient.Tests/Clients/FplEntryClientTests.cs
+++ b/src/FplClient.Tests/Clients/FplEntryClientTests.cs
@@ -47,7 +47,7 @@ namespace FplClient.Tests.Clients
         {
             public TestContext()
             {
-                Sut = new FplEntryClient(() => new HttpClient());
+                Sut = new FplEntryClient(new HttpClient());
             }
 
             public FplEntryClient Sut { get; }

--- a/src/FplClient.Tests/Clients/FplEntryHistoryClientTests.cs
+++ b/src/FplClient.Tests/Clients/FplEntryHistoryClientTests.cs
@@ -27,7 +27,7 @@ namespace FplClient.Tests.Clients
         {
             public TestContext()
             {
-                Sut = new FplEntryHistoryClient(() => new HttpClient());
+                Sut = new FplEntryHistoryClient(new HttpClient());
             }
 
             public FplEntryHistoryClient Sut { get; }

--- a/src/FplClient.Tests/Clients/FplFixtureClientTests.cs
+++ b/src/FplClient.Tests/Clients/FplFixtureClientTests.cs
@@ -36,7 +36,7 @@ namespace FplClient.Tests.Clients
         {
             public TestContext()
             {
-                Sut = new FplFixtureClient(() => new HttpClient());
+                Sut = new FplFixtureClient(new HttpClient());
             }
 
             public FplFixtureClient Sut { get; }

--- a/src/FplClient.Tests/Clients/FplGameweekClientTests.cs
+++ b/src/FplClient.Tests/Clients/FplGameweekClientTests.cs
@@ -29,7 +29,7 @@ namespace FplClient.Tests.Clients
         {
             public TestContext()
             {
-                Sut = new FplGameweekClient(() => new HttpClient());
+                Sut = new FplGameweekClient(new HttpClient());
             }
 
             public FplGameweekClient Sut { get; }

--- a/src/FplClient.Tests/Clients/FplLeagueClientTests.cs
+++ b/src/FplClient.Tests/Clients/FplLeagueClientTests.cs
@@ -45,7 +45,7 @@ namespace FplClient.Tests.Clients
         {
             public TestContext()
             {
-                Sut = new FplLeagueClient(() => new HttpClient());
+                Sut = new FplLeagueClient(new HttpClient());
             }
 
             public FplLeagueClient Sut { get; }

--- a/src/FplClient.Tests/Clients/FplPlayerClientTests.cs
+++ b/src/FplClient.Tests/Clients/FplPlayerClientTests.cs
@@ -34,7 +34,7 @@ namespace FplClient.Tests.Clients
         {
             public TestContext()
             {
-                Sut = new FplPlayerClient(() => new HttpClient());
+                Sut = new FplPlayerClient(new HttpClient());
             }
 
             public FplPlayerClient Sut { get; }

--- a/src/FplClient/Clients/FplEntryClient.cs
+++ b/src/FplClient/Clients/FplEntryClient.cs
@@ -9,25 +9,22 @@ namespace FplClient.Clients
 {
     public class FplEntryClient : IFplEntryClient
     {
-        private readonly Func<HttpClient> _clientFactory;
+        private readonly HttpClient _client;
 
-        public FplEntryClient(Func<HttpClient> clientFactory)
+        public FplEntryClient(HttpClient client)
         {
-            _clientFactory = clientFactory;
+            _client = client;
         }
 
         public async Task<FplBasicEntry> Get(int teamId)
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            using (var client = _clientFactory())
-            {
-                var url = $"https://fantasy.premierleague.com/drf/entry/{teamId}";
+            var url = $"https://fantasy.premierleague.com/drf/entry/{teamId}";
 
-                var json = await client.GetStringAsync(url);
+            var json = await _client.GetStringAsync(url);
 
-                return JsonConvert.DeserializeObject<FplBasicEntry>(json);
-            }
+            return JsonConvert.DeserializeObject<FplBasicEntry>(json);
         }
 
         [Obsolete("This no longer appears to return data as of September 2017.", false)]
@@ -35,28 +32,22 @@ namespace FplClient.Clients
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            using (var client = _clientFactory())
-            {
-                var url = $"https://fantasy.premierleague.com/drf/entry/{teamId}/event/{gameweek}";
+            var url = $"https://fantasy.premierleague.com/drf/entry/{teamId}/event/{gameweek}";
 
-                var json = await client.GetStringAsync(url);
+            var json = await _client.GetStringAsync(url);
 
-                return JsonConvert.DeserializeObject<FplEventEntry>(json);
-            }
+            return JsonConvert.DeserializeObject<FplEventEntry>(json);
         }
 
         public async Task<FplEntryPicks> GetPicks(int teamId, int gameweek)
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            using (var client = _clientFactory())
-            {
-                var url = $"https://fantasy.premierleague.com/drf/entry/{teamId}/event/{gameweek}/picks";
+            var url = $"https://fantasy.premierleague.com/drf/entry/{teamId}/event/{gameweek}/picks";
 
-                var json = await client.GetStringAsync(url);
+            var json = await _client.GetStringAsync(url);
 
-                return JsonConvert.DeserializeObject<FplEntryPicks>(json);
-            }
+            return JsonConvert.DeserializeObject<FplEntryPicks>(json);
         }
     }
 }

--- a/src/FplClient/Clients/FplEntryHistoryClient.cs
+++ b/src/FplClient/Clients/FplEntryHistoryClient.cs
@@ -9,25 +9,22 @@ namespace FplClient.Clients
 {
     public class FplEntryHistoryClient : IFplEntryHistoryClient
     {
-        private readonly Func<HttpClient> _clientFactory;
+        private readonly HttpClient _client;
 
-        public FplEntryHistoryClient(Func<HttpClient> clientFactory)
+        public FplEntryHistoryClient(HttpClient client)
         {
-            _clientFactory = clientFactory;
+            _client = client;
         }
 
         public async Task<FplEntryHistory> GetHistory(int teamId)
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            using (var client = _clientFactory())
-            {
-                var url = HistoryUrlFor(teamId);
+            var url = HistoryUrlFor(teamId);
 
-                var json = await client.GetStringAsync(url);
+            var json = await _client.GetStringAsync(url);
 
-                return JsonConvert.DeserializeObject<FplEntryHistory>(json);
-            }
+            return JsonConvert.DeserializeObject<FplEntryHistory>(json);
         }
 
         private static string HistoryUrlFor(int teamId)

--- a/src/FplClient/Clients/FplFixtureClient.cs
+++ b/src/FplClient/Clients/FplFixtureClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -10,39 +9,33 @@ namespace FplClient.Clients
 {
     public class FplFixtureClient : IFplFixtureClient
     {
-        private readonly Func<HttpClient> _clientFactory;
+        private readonly HttpClient _client;
 
-        public FplFixtureClient(Func<HttpClient> clientFactory)
+        public FplFixtureClient(HttpClient client)
         {
-            _clientFactory = clientFactory;
+            _client = client;
         }
 
         public async Task<IEnumerable<FplFixture>> GetFixtures()
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            using (var client = _clientFactory())
-            {
-                const string url = "https://fantasy.premierleague.com/drf/fixtures";
+            const string url = "https://fantasy.premierleague.com/drf/fixtures";
 
-                var json = await client.GetStringAsync(url);
+            var json = await _client.GetStringAsync(url);
 
-                return JsonConvert.DeserializeObject<IEnumerable<FplFixture>>(json);
-            }
+            return JsonConvert.DeserializeObject<IEnumerable<FplFixture>>(json);
         }
 
         public async Task<IEnumerable<FplFixture>> GetFixturesByGameweek(int id)
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            using (var client = _clientFactory())
-            {
-                string url = $"https://fantasy.premierleague.com/drf/fixtures/?event={id}";
+            var url = $"https://fantasy.premierleague.com/drf/fixtures/?event={id}";
 
-                var json = await client.GetStringAsync(url);
+            var json = await _client.GetStringAsync(url);
 
-                return JsonConvert.DeserializeObject<IEnumerable<FplFixture>>(json);
-            }
+            return JsonConvert.DeserializeObject<IEnumerable<FplFixture>>(json);
         }
     }
 }

--- a/src/FplClient/Clients/FplGameweekClient.cs
+++ b/src/FplClient/Clients/FplGameweekClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -10,25 +9,22 @@ namespace FplClient.Clients
 {
     public class FplGameweekClient : IFplGameweekClient
     {
-        private readonly Func<HttpClient> _clientFactory;
+        private readonly HttpClient _client;
 
-        public FplGameweekClient(Func<HttpClient> clientFactory)
+        public FplGameweekClient(HttpClient client)
         {
-            _clientFactory = clientFactory;
+            _client = client;
         }
 
         public async Task<IEnumerable<FplGameweek>> GetGameweeks()
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            using (var client = _clientFactory())
-            {
-                const string url = "https://fantasy.premierleague.com/drf/events";
+            const string url = "https://fantasy.premierleague.com/drf/events";
 
-                var json = await client.GetStringAsync(url);
+            var json = await _client.GetStringAsync(url);
 
-                return JsonConvert.DeserializeObject<IEnumerable<FplGameweek>>(json);
-            }
+            return JsonConvert.DeserializeObject<IEnumerable<FplGameweek>>(json);
         }
     }
 }

--- a/src/FplClient/Clients/FplGlobalSettingsClient.cs
+++ b/src/FplClient/Clients/FplGlobalSettingsClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FplClient.Data;
@@ -9,25 +8,22 @@ namespace FplClient.Clients
 {
     public class FplGlobalSettingsClient : IFplGlobalSettingsClient
     {
-        private readonly Func<HttpClient> _clientFactory;
+        private readonly HttpClient _client;
 
-        public FplGlobalSettingsClient(Func<HttpClient> clientFactory)
+        public FplGlobalSettingsClient(HttpClient client)
         {
-            _clientFactory = clientFactory;
+            _client = client;
         }
 
         public async Task<FplGlobalSettings> GetGlobalSettings()
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            using (var client = _clientFactory())
-            {
-                const string url = "https://fantasy.premierleague.com/drf/bootstrap-static";
+            const string url = "https://fantasy.premierleague.com/drf/bootstrap-static";
 
-                var json = await client.GetStringAsync(url);
+            var json = await _client.GetStringAsync(url);
 
-                return JsonConvert.DeserializeObject<FplGlobalSettings>(json);
-            }
+            return JsonConvert.DeserializeObject<FplGlobalSettings>(json);
         }
     }
 }

--- a/src/FplClient/Clients/FplLeagueClient.cs
+++ b/src/FplClient/Clients/FplLeagueClient.cs
@@ -9,39 +9,33 @@ namespace FplClient.Clients
 {
     public class FplLeagueClient : IFplLeagueClient
     {
-        private readonly Func<HttpClient> _clientFactory;
+        private readonly HttpClient _client;
 
-        public FplLeagueClient(Func<HttpClient> clientFactory)
+        public FplLeagueClient(HttpClient client)
         {
-            _clientFactory = clientFactory;
+            _client = client;
         }
 
         public async Task<FplClassicLeague> GetClassicLeague(int leagueId, int? page = null)
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            using (var client = _clientFactory())
-            {
-                var url = ClassicLeagueUrlFor(leagueId, page);
+            var url = ClassicLeagueUrlFor(leagueId, page);
 
-                var json = await client.GetStringAsync(url);
+            var json = await _client.GetStringAsync(url);
 
-                return JsonConvert.DeserializeObject<FplClassicLeague>(json);
-            }
+            return JsonConvert.DeserializeObject<FplClassicLeague>(json);
         }
 
         public async Task<FplHeadToHeadLeague> GetHeadToHeadLeague(int leagueId)
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            using (var client = _clientFactory())
-            {
-                var url = HeadToHeadLeagueUrlFor(leagueId);
+            var url = HeadToHeadLeagueUrlFor(leagueId);
 
-                var json = await client.GetStringAsync(url);
+            var json = await _client.GetStringAsync(url);
 
-                return JsonConvert.DeserializeObject<FplHeadToHeadLeague>(json);
-            }
+            return JsonConvert.DeserializeObject<FplHeadToHeadLeague>(json);
         }
 
         private static string ClassicLeagueUrlFor(int leagueId, int? page)

--- a/src/FplClient/Clients/FplPlayerClient.cs
+++ b/src/FplClient/Clients/FplPlayerClient.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -10,39 +9,33 @@ namespace FplClient.Clients
 {
     public class FplPlayerClient : IFplPlayerClient
     {
-        private readonly Func<HttpClient> _clientFactory;
+        private readonly HttpClient _client;
 
-        public FplPlayerClient(Func<HttpClient> clientFactory)
+        public FplPlayerClient(HttpClient client)
         {
-            _clientFactory = clientFactory;
+            _client = client;
         }
 
         public async Task<IEnumerable<FplPlayer>> GetAllPlayers()
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            using (var client = _clientFactory())
-            {
-                const string url = "https://fantasy.premierleague.com/drf/elements/";
+            const string url = "https://fantasy.premierleague.com/drf/elements/";
 
-                var json = await client.GetStringAsync(url);
+            var json = await _client.GetStringAsync(url);
 
-                return JsonConvert.DeserializeObject<IEnumerable<FplPlayer>>(json);
-            }
+            return JsonConvert.DeserializeObject<IEnumerable<FplPlayer>>(json);
         }
 
         public async Task<FplPlayerSummary> GetPlayer(int playerId)
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            using (var client = _clientFactory())
-            {
-                var url = PlayerSummaryUrlFor(playerId);
+            var url = PlayerSummaryUrlFor(playerId);
 
-                var json = await client.GetStringAsync(url);
+            var json = await _client.GetStringAsync(url);
 
-                return JsonConvert.DeserializeObject<FplPlayerSummary>(json);
-            }
+            return JsonConvert.DeserializeObject<FplPlayerSummary>(json);
         }
 
         private static string PlayerSummaryUrlFor(int playerId)

--- a/src/FplClient/FplClient.nuspec
+++ b/src/FplClient/FplClient.nuspec
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
-    <metadata>
-        <id>FplClient</id>
-        <version>2.0.0</version>
-        <title>FplClient</title>
-        <authors>Sean Comiskey</authors>
-        <owners>Sean Comiskey</owners>
-	<licenseUrl>https://github.com/RagtimeWilly/FplClient/LICENSE</licenseUrl>
-        <projectUrl>https://github.com/RagtimeWilly/FplClient/</projectUrl>
-        <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>.Net library which provides a simple interface for the official Fantasy Premier League API</description>
-        <copyright>Copyright � Sean Comiskey 2016</copyright>
-	<tags>fpl fantasy premier league</tags>
-        <dependencies>
-	  <dependency id="Newtonsoft.Json" version="12.0.2" />
-        </dependencies>
-    </metadata>
-    <files>
-        <file src="bin\Release\netstandard2.0\FplClient.dll" target="lib\netstandard2.0\FplClient.dll" />
-    </files>
+  <metadata>
+    <id>FplClient</id>
+    <version>3.0.0</version>
+    <title>FplClient</title>
+    <authors>Sean Comiskey</authors>
+    <owners>Sean Comiskey</owners>
+    <licenseUrl>https://github.com/RagtimeWilly/FplClient/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/RagtimeWilly/FplClient/</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>.Net library which provides a simple interface for the official Fantasy Premier League API</description>
+    <copyright>Copyright � Sean Comiskey 2016</copyright>
+	  <tags>fpl fantasy premier league</tags>
+    <dependencies>
+      <dependency id="Newtonsoft.Json" version="12.0.2" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="bin\Release\netstandard2.0\FplClient.dll" target="lib\netstandard2.0\FplClient.dll" />
+  </files>
 </package>


### PR DESCRIPTION
This is to allow the lifecycle of the HttpClient to be controlled outside of the client classes.