### PR TITLE
Update data objects to match the structure that the new API returns

### DIFF
--- a/src/FplClient/Data/FplFixture.cs
+++ b/src/FplClient/Data/FplFixture.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace FplClient.Data
@@ -25,7 +24,7 @@ namespace FplClient.Data
         public string FormattedDeadlineTime { get; set; }
 
         [JsonProperty("stats")]
-        public ICollection<FplFixtureStats> Stats { get; set; }
+        public FplFixtureStat[] Stats { get; set; }
 
         [JsonProperty("team_h_difficulty")]
         public int HomeTeamDifficulty { get; set; }

--- a/src/FplClient/Data/FplFixtureStat.cs
+++ b/src/FplClient/Data/FplFixtureStat.cs
@@ -5,6 +5,9 @@ namespace FplClient.Data
 {
     public class FplFixtureStat
     {
+        [JsonProperty("identifier")]
+        public string Identifier { get; set; }
+
         [JsonProperty("a")]
         public ICollection<FplFixtureStatValue> AwayStats { get; set; }
 

--- a/src/FplClient/Data/FplFixtureStatType.cs
+++ b/src/FplClient/Data/FplFixtureStatType.cs
@@ -9,6 +9,8 @@
         PenaltyMissed,
         YellowCard,
         RedCard,
-        Save
+        Save,
+        Bonus,
+        Bps
     }
 }

--- a/src/FplClient/Data/FplGlobalSettings.cs
+++ b/src/FplClient/Data/FplGlobalSettings.cs
@@ -28,15 +28,5 @@ namespace FplClient.Data
 
         [JsonProperty("total_players")]
         public long TotalPlayers { get; set; }
-
-        [JsonProperty("current-event")]
-        public int? CurrentEvent { get; set; }
-
-        [JsonProperty("next-event")]
-        public int? NextEvent { get; set; }
-
-        [JsonProperty("last-entry-event")]
-        public int? LastEntryEvent { get; set; }
-
     }
 }

--- a/src/FplClient/FplClient.nuspec
+++ b/src/FplClient/FplClient.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>FplClient</id>
-    <version>4.0.0</version>
+    <version>5.0.0</version>
     <title>FplClient</title>
     <authors>Sean Comiskey</authors>
     <owners>Sean Comiskey</owners>


### PR DESCRIPTION
My tool failed miserably on Friday night when the first fixture started. I've updated the objects to match the structure that the new api returns